### PR TITLE
Updating api documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Mar 04, 2025
+
+- Added `last_login` field to User/List and User/Show endpoints
+- Updated documenation to reflect Tradervue's URL change to app.tradervue.com
+
 ### Aug 22, 2016
 
 - Specify how trade and journal entry creation interacts with the user's notes templates.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Tradervue API
 =============
 
 The Tradervue API is a REST-style API for [Tradervue](http://www.tradervue.com)
-that uses JSON for serialization, and HTTP Basic authentication over 
+that uses JSON for serialization, and HTTP Basic authentication over
 SSL.
 
 Refer to the [change log](CHANGELOG.md) for the history of API changes.
@@ -10,7 +10,7 @@ Refer to the [change log](CHANGELOG.md) for the history of API changes.
 Making a request
 ----------------
 
-All URLs start with `https://www.tradervue.com/api/v1`, and are accessible via SSL only.
+All URLs start with `https://app.tradervue.com/api/v1`, and are accessible via SSL only.
 
 Authentication
 --------------
@@ -55,7 +55,7 @@ Tradervue-UserId: 78914
 If you do not have permission to issue API calls for the specified user, you will get a HTTP 403
 Not Authorized response.
 
-*Note: the "X-" prefix for non-standard headers has been deprecated 
+*Note: the "X-" prefix for non-standard headers has been deprecated
 in [RFC 6648](http://tools.ietf.org/html/rfc6648), which is why it is not used here.*
 
 Samples

--- a/comments.md
+++ b/comments.md
@@ -21,7 +21,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/trades/421249/comments"
+  "https://app.tradervue.com/api/v1/trades/421249/comments"
 ```
 
 ### Listing comments for journal entries
@@ -39,7 +39,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/journal/11473/comments"
+  "https://app.tradervue.com/api/v1/journal/11473/comments"
 ```
 
 ### Listing comments for journal notes
@@ -57,7 +57,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/notes/114712/comments"
+  "https://app.tradervue.com/api/v1/notes/114712/comments"
 ```
 
 ### Response

--- a/executions.md
+++ b/executions.md
@@ -21,7 +21,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/trades/659082/executions"
+  "https://app.tradervue.com/api/v1/trades/659082/executions"
 ```
 
 #### Response

--- a/imports.md
+++ b/imports.md
@@ -7,9 +7,9 @@ Imports
 -------
 
 Importing trade data in Tradervue is an asynchronous operation, due to the potentially large amount of
-data being processed and the time it might take. You make one API call to upload trade data and 
+data being processed and the time it might take. You make one API call to upload trade data and
 create a new import; you then make
-another call to retrieve the status of that import. 
+another call to retrieve the status of that import.
 
 No new imports can be created until the previous import has completed; you can tell when this happens
 by retrieving the status of the prior import. You are not required to retrieve the status, but it is
@@ -21,7 +21,7 @@ To read the import status from the previous import, you will use
 
 `GET /api/v1/imports`
 
-Querying the import status will clear it and reset it to "ready", unless the status indicates there 
+Querying the import status will clear it and reset it to "ready", unless the status indicates there
 is an import queued or processing. This call is not idempotent.
 
 #### Request
@@ -33,7 +33,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  https://www.tradervue.com/api/v1/imports
+  https://app.tradervue.com/api/v1/imports
 ```
 
 #### Response
@@ -120,7 +120,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"allow_duplicates":"false","overlay_commissions":"false","tags":["one","two"],"account_tag":"swing","executions":[{"datetime":"2013-02-7T09:53:34-05:00","symbol":"SPY","quantity":"100","price":"151.05","option":"","commission":"1.00","transfee":"0.04","ecnfee":"0.21"}]}' \
-  https://www.tradervue.com/api/v1/imports
+  https://app.tradervue.com/api/v1/imports
 ```
 
 A sample JSON request looks like this:
@@ -157,13 +157,13 @@ A sample JSON request looks like this:
 ```
 
 The datetime for each execution should be in ISO 8601 format (as shown above), but most date/time formats
-supported by the Tradervue [generic import format](http://www.tradervue.com/help/generic) should work if 
+supported by the Tradervue [generic import format](http://app.tradervue.com/help/generic) should work if
 combined into a single field (e.g. 2012-07-02 09:35:02).
 
 The quantity for each execution should be positive for a buy, and negative for a sell.
 
-For more details on each execution-related parameter, refer to the 
-[Generic Import Format documentation](http://www.tradervue.com/help/generic).
+For more details on each execution-related parameter, refer to the
+[Generic Import Format documentation](http://app.tradervue.com/help/generic).
 
 The other fields in the request are:
 
@@ -171,13 +171,13 @@ The other fields in the request are:
 when importing this data.
 
 - `overlay_commissions` - runs this import in commission-overlay mode; no new trades will be created, and
-existing trades will be updated with commission and fee data. See the Tradervue 
-[help article](http://www.tradervue.com/help/older_commissions) for more details.
+existing trades will be updated with commission and fee data. See the Tradervue
+[help article](http://app.tradervue.com/help/older_commissions) for more details.
 
 - `tags` - this is an array of tags you want applied to each new trade created in this import.
 
 - `account_tag` - allows you to specify an account tag to be used for the import; see
-[Account Tags](http://www.tradervue.com/help/account_tags) for more details.
+[Account Tags](http://app.tradervue.com/help/account_tags) for more details.
 
 Some features may not be functional depending on the subscription of the user; the same restrictions found
 in the Tradervue application are also enforced when using the API.

--- a/journal.md
+++ b/journal.md
@@ -21,7 +21,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/journal"
+  "https://app.tradervue.com/api/v1/journal"
 ```
 
 #### Response
@@ -61,7 +61,7 @@ enddate   | Filters results to entries on or before the end date, formatted as m
 
 ### Displaying a single journal entry
 
-You can retrieve details about a particular entry by using 
+You can retrieve details about a particular entry by using
 
 `GET /api/v1/journal/{id}`
 
@@ -74,7 +74,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/journal/12274"
+  "https://app.tradervue.com/api/v1/journal/12274"
 ```
 
 #### Response
@@ -98,7 +98,7 @@ The response will look like:
 }
 ```
 
-The `trade_ids` field will be an array of the id's of all of the trades that were completed, opened, 
+The `trade_ids` field will be an array of the id's of all of the trades that were completed, opened,
 closed, or adjusted on that date. Details about the trades can be retrieved with the [Trades API](trades.md).
 
 ### Updating a journal entry
@@ -123,7 +123,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"notes":"here are my updated notes"}' \
-  "https://www.tradervue.com/api/v1/journal/12274"
+  "https://app.tradervue.com/api/v1/journal/12274"
 ```
 
 A sample JSON request looks like this:
@@ -169,7 +169,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"date":"2015-12-05", "notes":"My notes for the day."}' \
-  "https://www.tradervue.com/api/v1/journal"
+  "https://app.tradervue.com/api/v1/journal"
 ```
 
 A sample JSON request looks like this:
@@ -191,7 +191,7 @@ If the notes field is omitted, the notes will be set from the user's default jou
 If successful, you will get a HTTP 201 response with a Location header containing the new entry's URL:
 
 ```
-Location: https://www.tradervue.com/api/v1/journal/13944
+Location: https://app.tradervue.com/api/v1/journal/13944
 ```
 
 The JSON response will include the new entry's ID:
@@ -229,7 +229,7 @@ curl -i \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -H "Content-type: application/json" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/journal/62245"
+  "https://app.tradervue.com/api/v1/journal/62245"
 ```
 
 If the journal entry could not be deleted, because there were trades completed on that date, you will get a HTTP 400 with a JSON response like

--- a/notes.md
+++ b/notes.md
@@ -22,7 +22,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/notes"
+  "https://app.tradervue.com/api/v1/notes"
 ```
 
 #### Response
@@ -57,7 +57,7 @@ page      | Specifies which page of results you want. For example, if you want r
 
 ### Displaying a single journal note
 
-You can retrieve details about a particular note by using 
+You can retrieve details about a particular note by using
 
 `GET /api/v1/notes/{id}`
 
@@ -70,7 +70,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/notes/11433"
+  "https://app.tradervue.com/api/v1/notes/11433"
 ```
 
 #### Response
@@ -107,7 +107,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"notes":"here are my updated notes"}' \
-  "https://www.tradervue.com/api/v1/notes/12274"
+  "https://app.tradervue.com/api/v1/notes/12274"
 ```
 
 A sample JSON request looks like this:
@@ -153,7 +153,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"notes":"My notes."}' \
-  "https://www.tradervue.com/api/v1/notes"
+  "https://app.tradervue.com/api/v1/notes"
 ```
 
 A sample JSON request looks like this:
@@ -169,7 +169,7 @@ A sample JSON request looks like this:
 If successful, you will get a HTTP 201 response with a Location header containing the new note's URL:
 
 ```
-Location: https://www.tradervue.com/api/v1/notes/13922
+Location: https://app.tradervue.com/api/v1/notes/13922
 ```
 
 The JSON response will include the new note's ID:
@@ -207,7 +207,7 @@ curl -i \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -H "Content-type: application/json" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/notes/22496"
+  "https://app.tradervue.com/api/v1/notes/22496"
 ```
 
 If the note wasn't found, you will get a HTTP 404.

--- a/trades.md
+++ b/trades.md
@@ -21,7 +21,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/trades"
+  "https://app.tradervue.com/api/v1/trades"
 ```
 
 #### Response
@@ -108,7 +108,7 @@ interactive reports, and examine the URL immediately after narrowing the filter,
 
 ### Displaying a single trade
 
-You can retrieve details about a particular trade by using 
+You can retrieve details about a particular trade by using
 
 `GET /api/v1/trades/{id}`
 
@@ -121,7 +121,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/trades/643888"
+  "https://app.tradervue.com/api/v1/trades/643888"
 ```
 
 #### Response
@@ -194,7 +194,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"notes":"here are my notes"}' \
-  "https://www.tradervue.com/api/v1/trades/659080"
+  "https://app.tradervue.com/api/v1/trades/659080"
 ```
 
 A sample JSON request looks like this:
@@ -249,7 +249,7 @@ curl -i \
   -H "Content-type: application/json" \
   -u example:password \
   -d '{"symbol":"AAAA","notes":"foo","initial_risk":25.0,"shared":false,"tags":["tag1","tag2"]}' \
-  "https://www.tradervue.com/api/v1/trades"
+  "https://app.tradervue.com/api/v1/trades"
 ```
 
 A sample JSON request looks like this:
@@ -277,7 +277,7 @@ If the notes field is omitted, the notes will be set from the user's default tra
 If successful, you will get a HTTP 201 response with a Location header containing the new trade's URL:
 
 ```
-Location: https://www.tradervue.com/api/v1/trades/12345
+Location: https://app.tradervue.com/api/v1/trades/12345
 ```
 
 The JSON response will include the new trade's ID:
@@ -315,5 +315,5 @@ curl -i \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -H "Content-type: application/json" \
   -u example:password \
-  "https://www.tradervue.com/api/v1/trades/46525"
+  "https://app.tradervue.com/api/v1/trades/46525"
 ```

--- a/users.md
+++ b/users.md
@@ -6,10 +6,11 @@ Users in an organization can be managed by the organization's manager using the 
 Making a request
 ----------------
 
-All URLs start with `https://www.tradervue.com/api/v1`, and are accessible via SSL only. The
-actual hostname should be your organization's URL; so for example, if you access your site
-at `https://traders-r-us.tradervue.com`, then the API root will be 
-`https://traders-r-us.tradervue.com/api/v1`.
+All URLs start with `https://app.tradervue.com/api/v1`, and are accessible via SSL only.
+
+**Important:** The actual hostname should be your organization's URL; so for example, if you access your site
+at `https://your-org.tradervue.com`, then the API root will be
+`https://your-org.tradervue.com/api/v1`.
 
 Authentication
 --------------
@@ -35,7 +36,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  https://www.tradervue.com/api/v1/users
+  https://your-org.tradervue.com/api/v1/users
 ```
 
 #### Response
@@ -50,14 +51,16 @@ The response will look like:
       "username": "test1",
       "email": "test1@example.com",
       "plan": "Free",
-      "billing_mode": "Tradervue CC"
+      "billing_mode": "Tradervue CC",
+      "last_login": "2023-09-06T08:05:41.294-04:00"
     },
     {
       "id": 10001,
       "username": "test2",
       "email": "test2@example.com",
       "plan": "Silver",
-      "billing_mode": "Managed"
+      "billing_mode": "Managed",
+      "last_login": "2025-01-07T13:09:04.702-05:00"
     }
   ]
 }
@@ -78,7 +81,7 @@ curl -i \
   -H "Accept: application/json" \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
-  https://www.tradervue.com/api/v1/users/10001
+  https://your-org.tradervue.com/api/v1/users/10001
 ```
 
 #### Response
@@ -91,7 +94,8 @@ The response will look like:
   "username": "test2",
   "email": "test2@example.com",
   "plan": "Silver",
-  "billing_mode": "Managed"
+  "billing_mode": "Managed",
+  "last_login": "2023-09-06T08:05:41.294-04:00"
 }
 ```
 
@@ -113,7 +117,7 @@ curl -i \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
   -d '{"plan":"Gold"}' \
-  https://www.tradervue.com/api/v1/users/10001
+  https://your-org.tradervue.com/api/v1/users/10001
 ```
 
 A sample JSON request looks like this:
@@ -158,7 +162,7 @@ curl -i \
   -H "User-Agent: MyApp (yourname@example.com)" \
   -u example:password \
   -d '{"username":"test3","plan":"Gold","email":"test3@example.com","password":"the_password"}' \
-  https://www.tradervue.com/api/v1/users
+  https://your-org.tradervue.com/api/v1/users
 ```
 
 A sample JSON request looks like this:
@@ -187,7 +191,7 @@ To create a user with a trial period, include the `trial_end` parameter, as in t
 ```
 
 If you specify an invalid trial end date, or one that exceeds the maximum trial length for your
-organization, you will get a 400 error and the user will not be created. 
+organization, you will get a 400 error and the user will not be created.
 
 You can also specify certain optional settings that the user will be created with, as in the following example:
 
@@ -254,7 +258,7 @@ each of the user's trades; parameters for each chart are as follows:
 If successful, you will get a HTTP 201 response with a Location header containing the new user's URL:
 
 ```
-Location: https://www.tradervue.com/api/v1/users/170
+Location: https://your-org.tradervue.com/api/v1/users/170
 ```
 
 The JSON response will include the new user's ID:


### PR DESCRIPTION
Hey @greinacker can you please review and merge the following changes?
It has been a long time since we changed the Tradervue URL to `app.tradervue.com,`  and this documentation is causing users some confusion. 
I'll be sending PRs for the sample projects shortly too. 

Thanks in advance!

- Reflects the new app url: app.tradervue.com
- Adds last_login field to user/show and user/list endpoints